### PR TITLE
Test that inline and fenced code are ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ It works by hooking into the rendering process of markdown-it, and gives you cal
 
 You'll need to provide the code for those callbacks; the use-case envisaged is that your test suite checks spellings and can fail a build if errors are found.
 
-**Note:** this does **not** yet check HTML blocks (which you may be using if you prefer to do tables in HTML rather than the visual markdown syntax, for example), but this is a planned feature.  It **does** check inline HTML already.
-
 Refer to [example.js](example.js) (and [example.md](example.md)) for a real-world example.
 
 ```javascript
@@ -27,6 +25,12 @@ const md = require('markdown-it')()
 
 md.render(fs.readFileSync('a-markdown-file.md').toString())
 ```
+
+Notes
+-----
+
+* The contents of inline code spans and fenced code blocks are not checked.
+* this does **not** yet check HTML blocks (which you may be using if you prefer to do tables in HTML rather than the visual markdown syntax, for example), but this is a planned feature.  It **does** check inline HTML already.
 
 Options
 -------

--- a/fixtures/ignore-within-fenced.md
+++ b/fixtures/ignore-within-fenced.md
@@ -1,0 +1,5 @@
+Surround incorrect
+
+```
+Spellrite
+```

--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,10 @@
 'use strict'
+const fs = require('fs')
+const path = require('path')
+
+function getFixture(name) {
+	return fs.readFileSync(path.join('fixtures', name)).toString()
+}
 
 describe('options-checking', () => {
 	it('throws when no options are specified', () => {
@@ -237,5 +243,32 @@ describe('valid words and warning words', () => {
 		expect(errorsMock.mock.calls.length).toBe(0)
 		expect(warningsMock.mock.calls.length).toBe(1)
 		expect(warningsMock.mock.calls[0][0]).toEqual(['Spellrite'])
+	})
+})
+
+describe('ignoring code', () => {
+	let md
+	let errorsMock
+	let warningsMock
+
+	beforeEach(() => {
+		errorsMock = jest.fn()
+		warningsMock = jest.fn()
+		md = require('markdown-it')().use(require('./'), {
+			errors: errorsMock,
+			warnings: warningsMock
+		})
+	})
+
+	it('ignores `code` spans', () => {
+		md.render('Surround incorrect `Spellrite` in a code span.')
+		expect(errorsMock.mock.calls.length).toBe(0)
+		expect(warningsMock.mock.calls.length).toBe(0)
+	})
+
+	it('ignores fenced code blocks', () => {
+		md.render(getFixture('ignore-within-fenced.md'))
+		expect(errorsMock.mock.calls.length).toBe(0)
+		expect(warningsMock.mock.calls.length).toBe(0)
 	})
 })


### PR DESCRIPTION
They are ignored, but it is useful to have the tests to document this.
The README has also been updated to make this clear.