### PR TITLE
Factor out CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+## [0.3.1](https://github.com/matatk/markdown-it-spellcheck/compare/0.3.0...0.3.1) (2018-01-26)
+
+* Do not depend on [yargs](http://yargs.js.org) for the example (there is [markdown-spellcheck-cli](https://github.com/matatk/markdown-spellcheck-cli) for that now).
+* Update README with links to the CLI tool and fill in placeholders for the possible options in the "hello, world" example.
+
 ## [0.3.0](https://github.com/matatk/markdown-it-spellcheck/compare/0.2.0...0.3.0) (2018-01-24)
 
 * Use factored-out [core-text-spellcheck](https://github.com/matatk/core-text-spellcheck) package (which, amongst other things, allows the word lists to be given as empty arrays, in order to make reacting to user settings easier when passing through options).

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ markdown-it-spellcheck
 
 This is a plug-in for [markdown-it](https://github.com/markdown-it/markdown-it) that you can use to spell-check your markdown files.
 
-It works by hooking into the rendering process of markdown-it, and gives you callbacks that you can use to track any spelling errors or warnings. You can also add words to the custom dictionary, and set up a filter function to allow some pre-processing.
+It works by hooking into the rendering process of markdown-it, and gives you callbacks that you can use to track any spelling errors or warnings. You can also add words to the custom dictionary, and set up a filter function to allow some pre-processing. You'll need to provide the code for those callbacks; the use-case envisaged is that your test suite checks spellings and can fail a build if errors are found.
 
-You'll need to provide the code for those callbacks; the use-case envisaged is that your test suite checks spellings and can fail a build if errors are found.
-
-Refer to [example.js](example.js) (and [example.md](example.md)) for a real-world example.
+A command-line markdown spell-checker, [markdown-spellcheck-cli](https://github.com/matatk/markdown-spellcheck-cli), is available. Refer to [example.js](example.js) (and [example.md](example.md)) for a demo of filtering. The "hello, world" code is as follows.
 
 ```javascript
 const fs = require('fs')
@@ -21,6 +19,10 @@ const md = require('markdown-it')()  // { html: true } if you use HTML blocks/in
 		warnings: (warnings) => {
 			console.log(`Warnings: ${warnings.join(', ')}`)
 		}
+		// log: null,
+		// validWords: [],
+		// warnWords: [],
+		// filter: null
 	})
 
 md.render(fs.readFileSync('a-markdown-file.md').toString())

--- a/example.js
+++ b/example.js
@@ -2,23 +2,8 @@
 const fs = require('fs')
 const markdownit = require('markdown-it')
 
-const argv = require('yargs')
-	.usage('Usage: $0 [options]')
-	.boolean('filenames')
-	.describe('filenames', 'List files being checked')
-	.alias('f', 'filenames')
-	.boolean('debug')
-	.describe('debug', 'Show debugging info')
-	.alias('d', 'debug')
-	.help()
-	.alias('h', 'help')
-	.argv
-
 function findErrorsInFile(md, fileName) {
-	if (argv.filenames) {
-		console.log(`Checking file: "${fileName}"...`)
-	}
-
+	console.log(`Checking file: "${fileName}"...`)
 	md.render(fs.readFileSync(fileName).toString())
 }
 
@@ -29,7 +14,9 @@ function main() {
 
 	const md = markdownit({ html: true })
 		.use(require('./'), {
-			log: argv.debug ? console.log : null,
+			log: (info) => {
+				console.log(`Info: ${info}`)
+			},
 			errors: (errors) => {
 				console.log(`Error: ${currentFile}: ${errors.join(', ')}`)
 				foundErrors++

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-spellcheck",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Check spelling in markdown files (markdown-it plugin)",
   "keywords": [
@@ -16,7 +16,7 @@
   "main": "index.js",
   "scripts": {
     "precommit": "npm test",
-    "example": "node example.js -fd",
+    "example": "node example.js",
     "test": "eslint . && jest"
   },
   "dependencies": {
@@ -27,8 +27,7 @@
     "eslint": "~4.16",
     "husky": "~0.14",
     "jest": "~22.1",
-    "markdown-it": "~8.4",
-    "yargs": "~11.0"
+    "markdown-it": "~8.4"
   },
   "jest": {
     "collectCoverage": true


### PR DESCRIPTION
* Don't depend on yargs (refer to markdown-spellcheck-cli for a full CLI
example).
* README updates for the above and to add options' defaults.